### PR TITLE
use r10k instead of librarian-puppet to bootstrap puppet modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-modules
+/modules/*
+!/modules/.gitkeep
 Puppetfile.lock
 .librarian
 .tmp

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,5 +1,8 @@
 forge "https://forge.puppetlabs.com"
 
-mod 'hardening/os_hardening', '>= 0.1.1'
-mod 'hardening/ssh_hardening'
+mod 'puppetlabs/stdlib', :latest
+mod 'thias/sysctl', :latest
+mod 'saz/ssh', :latest
+mod 'hardening/os_hardening', :latest
+mod 'hardening/ssh_hardening', :latest
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,9 @@ Demonstrates the use of hardening modules via puppet. Use either Vagrant or Dock
 
 ## Vagrant
 
-You will require `librarian-puppet` for module resolution:
+All necessary modules will be automatically fetched by r10k.
 
-    gem install librarian-puppet
-
-Load modules:
-
-    librarian-puppet install
-
-Once done, get your box up:
+To get your box up and running:
 
     vagrant up ubuntu-trusty
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Demonstrates the use of hardening modules via puppet. Use either Vagrant or Dock
 
 ## Vagrant
 
-All necessary modules will be automatically fetched by r10k. Just make sure the modules directory exist:
-
-    mkdir -p modules
+All necessary modules will be automatically fetched by r10k. 
 
 To get your box up and running:
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ Demonstrates the use of hardening modules via puppet. Use either Vagrant or Dock
 
 ## Vagrant
 
-All necessary modules will be automatically fetched by r10k.
+All necessary modules will be automatically fetched by r10k. Just make sure the modules directory exist:
+
+    mkdir -p modules
 
 To get your box up and running:
 
-    vagrant up ubuntu-trusty
+    vagrant up
 
 That's it. Enjoy testing your box via:
 
-    vagrant ssh ubuntu-trusty
+    vagrant ssh
 
 
 ## Docker

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,14 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+$script = <<BOOTSTRAP
+apt-get update -qq
+[ -x /usr/bin/git ] || apt-get install -y -q git
+[ -x /usr/bin/make ] || apt-get install -y -q make
+gem list r10k -i 1>/dev/null || gem install --quiet --no-rdoc --no-ri r10k 1>/dev/null
+cd /vagrant && r10k -v info puppetfile install
+BOOTSTRAP
+
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
@@ -11,7 +19,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     c.vm.box = "trusty64"
     c.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
 
-    c.vm.provision :shell, :path => "bootstrap.sh"
+    c.vm.provision :shell, inline: $script
     c.vm.provision :puppet do |puppet|
       puppet.module_path = "modules"
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     c.vm.box = "trusty64"
     c.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
 
-    c.vm.provision :shell, inline: "apt-get update"
+    c.vm.provision :shell, :path => "bootstrap.sh"
     c.vm.provision :puppet do |puppet|
       puppet.module_path = "modules"
     end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -
+
+apt-get update -qq
+[ -x /usr/bin/git ] || apt-get install -y -q git
+[ -x /usr/bin/make ] || apt-get install -y -q make
+gem list r10k -i 1>/dev/null || gem install --quiet --no-rdoc --no-ri r10k 1>/dev/null
+cd /vagrant && r10k -v info puppetfile install
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -
-
-apt-get update -qq
-[ -x /usr/bin/git ] || apt-get install -y -q git
-[ -x /usr/bin/make ] || apt-get install -y -q make
-gem list r10k -i 1>/dev/null || gem install --quiet --no-rdoc --no-ri r10k 1>/dev/null
-cd /vagrant && r10k -v info puppetfile install
-


### PR DESCRIPTION
r10k is an alternative approach to bootstrap puppet modules (from forge or elsewhere) in a Vagrant environment.